### PR TITLE
Prevent irrelevant scrollbars on `.wrapper`

### DIFF
--- a/src/css/_site.scss
+++ b/src/css/_site.scss
@@ -5,7 +5,7 @@
 	margin: 0 auto;
 	width: 90%;
 	max-width: 500px;
-	overflow-x: scroll;
+	overflow-x: hidden; // Changed to `hidden` to avoid irrelevant horizontal scrollbars
 }
 .section {
 	margin-bottom: 40px;


### PR DESCRIPTION
All elements with a `wrapper` class used to have a horizontal(`overflow-x`)  scrollbar as the property value was set to `scroll`.
Changed to `hidden`.
